### PR TITLE
Fix the rolling period value to 144

### DIFF
--- a/app/src/main/java/nl/rijksoverheid/en/lab/NotificationsRepository.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/lab/NotificationsRepository.kt
@@ -46,6 +46,10 @@ class NotificationsRepository(
     private val exposureNotificationClient: ExposureNotificationClient
 ) {
 
+    companion object {
+        const val DEFAULT_ROLLING_PERIOD = 144
+    }
+
     private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     private val exposuresAdapter = moshi.adapter<List<ExposureInfo>>(
         Types.newParameterizedType(
@@ -66,6 +70,12 @@ class NotificationsRepository(
 
     suspend fun getStatus(): StatusResult {
         return exposureNotificationClient.getStatus()
+    }
+
+    fun clearExposureInformation() {
+        measurements.edit {
+            putString("result", "[]")
+        }
     }
 
     suspend fun storeExposureInformation(token: String) {

--- a/app/src/main/java/nl/rijksoverheid/en/lab/keys/KeysFragment.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/lab/keys/KeysFragment.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 import nl.rijksoverheid.en.lab.BaseFragment
+import nl.rijksoverheid.en.lab.NotificationsRepository
 import nl.rijksoverheid.en.lab.R
 import nl.rijksoverheid.en.lab.barcodescanner.BarcodeScanActivity
 import nl.rijksoverheid.en.lab.databinding.FragmentKeysBinding
@@ -58,7 +59,7 @@ class KeysFragment : BaseFragment(R.layout.fragment_keys) {
             val tek = TemporaryExposureKey.TemporaryExposureKeyBuilder().apply {
                 setKeyData(Base64.decode(json.getString("keyData"), 0))
                 setRollingStartIntervalNumber(json.getString("rollingStartNumber").toInt())
-                setRollingPeriod(json.getString("rollingPeriod").toInt())
+                setRollingPeriod(NotificationsRepository.DEFAULT_ROLLING_PERIOD)
                 setTransmissionRiskLevel(1)
             }.build()
             viewModel.importKey(tek)

--- a/app/src/main/java/nl/rijksoverheid/en/lab/keys/KeysViewModel.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/lab/keys/KeysViewModel.kt
@@ -20,6 +20,7 @@ class KeysViewModel(private val repository: NotificationsRepository) : ViewModel
         repository.getExposureInformation().asLiveData(context = viewModelScope.coroutineContext)
 
     fun importKey(tek: TemporaryExposureKey) {
+        repository.clearExposureInformation()
         viewModelScope.launch {
             repository.importTemporaryExposureKey(tek)
         }

--- a/app/src/main/java/nl/rijksoverheid/en/lab/status/NotificationsStatusViewModel.kt
+++ b/app/src/main/java/nl/rijksoverheid/en/lab/status/NotificationsStatusViewModel.kt
@@ -139,7 +139,7 @@ class NotificationsStatusViewModel(private val repository: NotificationsReposito
             )
             .put(
                 "rollingPeriod",
-                latestKey.rollingPeriod
+                NotificationsRepository.DEFAULT_ROLLING_PERIOD
             )
             .put(
                 "transmissionRiskLevel",


### PR DESCRIPTION
Setting 0 for rolling period, the value that is returned by default on a TemporaryExposureKey does not seem to work anymore when importing a key. Since a TEK in the gaen protocol currently always has a validity of 1 day, this value can be considered a constant of 144.

Additionally this PR also clears the previous stored exposures before importing importing a new key.